### PR TITLE
Update the namelists for changes at 212_POP-Prepare-for-CMIP6

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Copy these scripts to do the desired run directory on Gadi. Access to the HH5 pr
 * Specify the location of the ```cable``` repository, by setting the ```cablecode``` variable on line 46.
 * Set the experiment to run by setting the ```experiment``` variable on line 26. The experiment names correspond to a set of internal configuration options.
 
-It's still not entirely clear what each of the experiments do. This will be clarified after discussions with the original custodians of the configuration.
+It's still not entirely clear what each of the experiments do. This will be clarified after discussions with the original custodians of the configuration. At the moment, I think the ```S0``` run is the one that works as intended straight out of the box. Some work on ```run_cable.sh``` will be required to set the meteorogical recycling and atmospheric CO2/N deposition correctly for the other runs.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,26 @@ Copy these scripts to do the desired run directory on Gadi. Access to the HH5 pr
 * Specify the location of the ```cable``` repository, by setting the ```cablecode``` variable on line 46.
 * Set the experiment to run by setting the ```experiment``` variable on line 26. The experiment names correspond to a set of internal configuration options.
 
-It's still not entirely clear what each of the experiments do. This will be clarified after discussions with the original custodians of the configuration. At the moment, I think the ```S0``` run is the one that works as intended straight out of the box. Some work on ```run_cable.sh``` will be required to set the meteorogical recycling and atmospheric CO2/N deposition correctly for the other runs.
+The changes in this branch as compared to the trunk reflect a series of changes to the Met input routines which are currently contained in CABLE PR [290](https://github.com/CABLE-LSM/CABLE/pull/290). The changes are a first pass at making the input routines generalised. The namelist options ```Run``` and ```MetVersion``` that set a series of options inside the code have been removed, and replaced with options in ```cru.nml``` which permit the same behaviour.
 
-## Resources
+The Met files are required to be named with a certain format, that contains the start and end date of the data in the given file in YYYYMMDD format. The start and end dates are represented by <startdate> and <enddate> in the namelist option. Taking an example from the most recent TRENDY version, the file ```crujra.v2.4.5d.pre.1901.365d.noc.daytot.1deg.nc``` can be symlinked to ```precip-19010101-19011231.nc```, and the ```rainFile``` namelist option set to ```precip-<startdate>-<enddate>.nc``` to allow it to be read by the new routines. This also handles files which span multiple years (but for now, only files which contain full years). This should allow easier substituting in and out of different Met forcing datasets.
 
-The default job configuration, with 100 parallel runs, takes ~8 hours, 450GB of memory and ~12000 files, so ensure that the file system you are running on has the required resources.
+The possible internal names for each Met variable are handled by pre-preparing a set of possible Met names stored in ```namelists/met_names.nml```, which contains the possible NetCDF variable names to check for.
+
+A summary of the new namelist options in the ```cru.nml``` are:
+* <variable>File: ```CHARACTER(256)```, template matching the set of files for a given met variable. Includes ```NDep```. Defaults to ```"None"```.
+* CO2File: ```CHARACTER(256)```, location of the CO2 file. Given that the CO2 values are currently stored in a columnated text file, it does not yet require the templated format. Defaults to ```"None"```.
+* LandmaskFile: ```CHARACTER(256)```, location of the landmask file. Defaults to ```"None"```.
+* <variable>Recycle: ```LOGICAL```, whether the given variable is recycled. Defaults to ```.FALSE.```.
+* CO2Method: ```CHARACTER(16)```, method for choosing the CO2 values. Either "Yearly" to read the current run year, or the desired year as a string. Defaults to ```"Yearly"```.
+* NDepMethod: ```CHARACTER(16)```, method for choosing the NDep values. Either "Yearly" to read the current run year, or the desired year as a string. Defaults to ```"Yearly"```.
+* LeapYears: ```LOGICAL```, whether the Met dataset contains leap years. Defaults to ```.FALSE.```
+* DtHrs: ```REAL```, time step in hours. Defaults to ```3.0```.
+* MetRecyc: ```INTEGER```, period for the met recycling. Defaults to ```20```.
+* ReadDiffFrac: ```LOGICAL```, whether to read the diffusive fraction from file or allow CABLE to calculate it. Defaults to ```.TRUE.```.
+* Directread: ```LOGICAL```, whether to read the Met data directly from NetCDF files into vectors, or read into an array then into vectors. Defaults to ```.FALSE.```.
+
+The ```run_cable.sh``` script has been modified to appropriately change the ```cru.nml``` namelist options for the different scenarios 0 through 3.
+
+
+

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Gadi
+# https://opus.nci.org.au/display/Help/How+to+submit+a+job
+#PBS -N CABLE_cleanup
+#PBS -P pr09
+#PBS -q normal
+#PBS -l walltime=00:30:00
+#PBS -l mem=1GB
+#PBS -l ncpus=1
+#PBS -l storage=gdata/x45+scratch/pt17+gdata/pr09+scratch/pr09
+#PBS -l software=netCDF:MPI:Intel:GNU:scorep
+#PBS -r y
+#PBS -l wd
+#PBS -j oe
+#PBS -S /bin/bash
+
+exp_name='TRENDY_S0'
+outpath='/g/data/pr09/TRENDY_v12/S0'
+nruns=100
+climate_restart='cru_climate_rst'
+keep_dump=1
+mergesteps='1700_1900 1901_2022'
+
+
+# executable
+mkdir -p ${outpath}/exe
+mv ${outpath}/run1/cable ${outpath}/exe/.
+
+# PBS log files
+mkdir -p ${outpath}/PBS
+mv ${PWD}/${exp_name}.o* ${outpath}/PBS/.
+
+for ((irun=1; irun<=${nruns}; irun++)) ; do
+
+    # Restart files (includes namelists)
+    mkdir -p ${outpath}/restart/run${irun}
+    mv ${outpath}/run${irun}/restart/* ${outpath}/restart/run${irun}/.
+
+    # Climate restart
+    mkdir -p ${outpath}/climate_restart
+    mv ${outpath}/run${irun}/${climate_restart}.nc ${outpath}/climate_restart/${climate_restart}${irun}.nc
+
+    # log files
+    mkdir -p ${outpath}/logs/run${irun}
+    mv ${outpath}/run${irun}/logs/* ${outpath}/logs/run${irun}/.
+
+    # landmasks
+    mkdir -p ${outpath}/landmasks
+    mv ${outpath}/run${irun}/landmask/landmask${irun}.nc ${outpath}/landmasks/.
+
+    # dump files
+    if [[ ${keep_dump} -eq 1 || ("${outpath}" == "S3*" && ("${mergesteps}" == "*1700_1900" || "${mergesteps}" == "1901_*")) ]] ; then
+        mkdir -p ${outpath}/dump_files/run${irun}
+        mv ${outpath}/run${irun}/*_dump.nc ${outpath}/dump_files/run${irun}/.
+    fi
+
+    # delete all the rest
+    rm -r ${outpath}/run${irun}/
+done

--- a/namelists/cru.nml
+++ b/namelists/cru.nml
@@ -1,10 +1,29 @@
-&crunml
-    BasePath     = "/g/data/x45/CRUJRA2021/daily_1deg"
-    MetPath      = "/g/data/x45/CRUJRA2021/daily_1deg"
-    MetVersion   = "CRUJRA_2022"
-    ReadDiffFrac = .FALSE.
+&MetConfig
+    rainFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/pre/pre_<startdate>_<enddate>.nc"
+    lwdnFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/dlwrf/dlwrf_<startdate>_<enddate>.nc"
+    swdnFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/tswrf/tswrf_<startdate>_<enddate>.nc"
+    presFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/pres/pres_<startdate>_<enddate>.nc"
+    qairFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/spfh/spfh_<startdate>_<enddate>.nc"
+    TmaxFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/tmax/tmax_<startdate>_<enddate>.nc"
+    TminFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/tmin/tmin_<startdate>_<enddate>.nc"
+    uwindFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/ugrd/ugrd_<startdate>_<enddate>.nc"
+    vwindFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/vgrd/vgrd_<startdate>_<enddate>.nc"
+    fDiffFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/fd/fd_<startdate>_<enddate>.nc"
+    CO2File = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/co2/co2_17000101_20221231.txt"
+    NDepFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/ndep/NDep_<startdate>_<enddate>.nc"
     LandMaskFile = "/g/data/x45/ipbes/masks/glob_ipsl_1x1.nc"
-    Run          = "S0_TRENDY"
+    rainRecycle = T
+    lwdnRecycle = T
+    swdnRecycle = T
+    presRecycle = T
+    qairRecycle = T
+    TmaxRecycle = T
+    TminRecycle = T
+    uWindRecycle = T
+    vWindRecycle = T
+    fDiffRecycle = T
+    CO2Method = "1700"
+    NDepMethod = "1850"
+    ReadDiffFrac = .FALSE.
     DThrs        = 3.0                ! **CABLE** timestep hours (not the met timestep)
-    DirectRead   = .TRUE.
 /

--- a/namelists/cru.nml
+++ b/namelists/cru.nml
@@ -1,4 +1,4 @@
-&MetConfig
+&crunml
     rainFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/pre/pre_<startdate>_<enddate>.nc"
     lwdnFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/dlwrf/dlwrf_<startdate>_<enddate>.nc"
     swdnFile = "/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/tswrf/tswrf_<startdate>_<enddate>.nc"
@@ -26,4 +26,5 @@
     NDepMethod = "1850"
     ReadDiffFrac = .FALSE.
     DThrs        = 3.0                ! **CABLE** timestep hours (not the met timestep)
+    LeapYears    = .FALSE.
 /

--- a/namelists/met_names.nml
+++ b/namelists/met_names.nml
@@ -1,0 +1,12 @@
+&MetNames
+rainNo = 3, rainNames = "rain" "Precipalign" "pre",
+lwdnNo = 3, lwdnNames = "dlwrf" "LWdownnoalign" "rlds",
+swdnNo = 4, swdnNames = "dswrf" "tswrf" "SWdownnoalign" "rsds",
+presNo = 3, presNames = "pres" "Psurfnoalign" "ps",
+qairNo = 3, qairNames = "spfh" "Qairnoalign" "huss",
+TmaxNo = 3, TmaxNames = "tmax" "Tmaxnoalign" "tasmax",
+TminNo = 3, TminNames = "tmin", "Tminnoalign" "tasmin",
+uwindNo = 3, uwindNames = "ugrd", "Wind_Enoalign" "uas",
+vwindNo = 3, vwindNames = "vgrd", "Wind_Nnoalign" "vas",
+fdiffNo = 1, fdiffNames = "fd",
+/

--- a/run_TRENDY.sh
+++ b/run_TRENDY.sh
@@ -58,6 +58,10 @@ cleanup_script="${rundir}/cleanup.sh"
 # Cable executable- we should move this to bin
 exe="${cablecode}/offline/cable"
 
+# Add the scripts directory to the pythonpath for cablepop python module
+export PYTHONPATH=${cablecode}/scripts:${PYTHONPATH}
+
+
 # The location of the data- note that the "aux" variable has been removed,
 # and all the data now lives in rp23/no_provenance
 datadir="/g/data/rp23/data/no_provenance/"

--- a/run_TRENDY.sh
+++ b/run_TRENDY.sh
@@ -23,7 +23,7 @@ module load conda_concept/analysis3
 #-------------------------------------------------------
 # Settings
 #-------------------------------------------------------
-experiment=""
+experiment="S0"
 experiment_name="${experiment}"
 run_model=1       # run the model or just do other steps (e.g. merging)?
 merge_results=0   # after runs are finished, merge results into one folder and backup 
@@ -34,9 +34,9 @@ mergesteps="1700_1900 1901_2022"
 
 ### Spatial subruns ###
 create_landmasks=1               # create new landmask files (1) or use existing ones (0)?
-nruns=100                        # number of runs in parallel
-#extent="64.0,66.0,60.0,62.0"    # "global" or "lon_min,lon_max,lat_min,lat_max"
-extent="global"
+nruns=4                        # number of runs in parallel
+extent="64.0,66.0,60.0,62.0"    # "global" or "lon_min,lon_max,lat_min,lat_max"
+#extent="global"
 climate_restart="cru_climate_rst"       # name of climate restart file (without file extension)
 keep_dump=1                             # keep dump files (1) or discard (0)? They are always kept for LUC runs
 
@@ -66,8 +66,7 @@ export PYTHONPATH=${cablecode}/scripts:${PYTHONPATH}
 # and all the data now lives in rp23/no_provenance
 datadir="/g/data/rp23/data/no_provenance/"
 # Global Meteorology
-GlobalMetPath="${datadir}/met_forcing/crujra_1x1_1d/v2.4"
-MetVersion="CRUJRA_2023"
+GlobalMetPath="/g/data/rp23/experiments/2024-03-12_CABLE4-dev/lw5085/data_links/"
 # Global LUC
 GlobalTransitionFilePath="${datadir}/luc/LUH2_GCB_1x1/v2023"
 # Global Surface file 
@@ -98,7 +97,6 @@ if [[ ${run_model} -eq 1 ]] ; then
 	 sed -i "s!^datadir=.*!datadir='${datadir}'!" $run_script
     sed -i "s!^exe=.*!exe='${exe}'!" $run_script
     sed -i "s!^MetPath=.*!MetPath='${GlobalMetPath}'!" $run_script
-    sed -i "s!^MetVersion=.*!MetVersion='${MetVersion}'!" $run_script
     sed -i "s!^TransitionFilePath=.*!TransitionFilePath='${GlobalTransitionFilePath}'!" $run_script
     sed -i "s!^SurfaceFile=.*!SurfaceFile='${SurfaceFile}'!" $run_script
 

--- a/run_cable.sh
+++ b/run_cable.sh
@@ -2,7 +2,7 @@
 
 # Gadi
 # https://opus.nci.org.au/display/Help/How+to+submit+a+job
-#PBS -N TRENDY_S1
+#PBS -N TRENDY_S0
 #PBS -P rp23
 #PBS -q normal
 #PBS -p 600
@@ -68,9 +68,9 @@ if [[ ! -z ${mpiexecdir} ]] ; then export mpiexecdir="${mpiexecdir}/" ; fi
 ## Basic settings (parsed through from wrapper script)
 ## ------------------------------------------------------------------
 # TRENDY experiment (S0, S1, S2, S3, S4, S5, S6):     
-experiment='S1'
+experiment='S0'
 # Name of the experiment (= name of output folder)     
-experiment_name='S1'
+experiment_name='S0'
 # Code directory
 cablecode='/home/564/lw5085/CABLE'
 # Script directory
@@ -88,19 +88,19 @@ TransitionFilePath='/g/data/rp23/data/no_provenance/luc/LUH2_GCB_1x1/v2023'
 # Global Surface file 
 SurfaceFile='/g/data/rp23/data/no_provenance/gridinfo/gridinfo_CSIRO_1x1.nc'
 # Output directory of the run
-runpath='/scratch/rp23/lw5085/TRENDY_V12/S1/run4'
+runpath='/scratch/rp23/lw5085/TRENDY_V12/S0/run4'
 # Land Mask used for this run
-LandMaskFile='/scratch/rp23/lw5085/TRENDY_V12/S1/run4/landmask/landmask4.nc'
+LandMaskFile='/scratch/rp23/lw5085/TRENDY_V12/S0/run4/landmask/landmask4.nc'
 
 
 ## ----------------------------------------------------------------
 ## Run Sequence
 ## ----------------------------------------------------------------
-doclimate=0     # 1/0: Do/Do not create climate restart file
-dofromzero=0    # 1/0  Do/Do not first spinup phase from zero biomass stocks
-doequi1=0       # 1/0: Do/Do not bring biomass stocks into quasi-equilibrium with unrestricted P and N pools
+doclimate=1     # 1/0: Do/Do not create climate restart file
+dofromzero=1    # 1/0  Do/Do not first spinup phase from zero biomass stocks
+doequi1=1       # 1/0: Do/Do not bring biomass stocks into quasi-equilibrium with unrestricted P and N pools
     nequi1=3        #      number of times to repeat steps in doequi1  4
-doequi2=0       # 1/0: Do/Do not bring biomass stocks into quasi-equilibrium with restricted P and N pools
+doequi2=1       # 1/0: Do/Do not bring biomass stocks into quasi-equilibrium with restricted P and N pools
     nequi2=15       #      number of times to repeat steps in doequi2  14
     nequi2a=5       #      number of times to repeat analytic spinup in this step 5
 if [[ "${experiment}" == "S3" ]] ; then
@@ -943,7 +943,7 @@ if [[ ${dofinal} -eq 1 ]] ; then
              CO2Method = "Yearly"
              NDepMethod = "Yearly"
 EOF
-    elif [[ "${experiment}" == "S2" ]] ; then
+    elif [[ "${experiment}" == "S2" || "${experiment}" == "S3" ]] ; then
         cat > ${tmp}/sedtmp.${pid} << EOF
              CO2Method = "Yearly"
              NDepMethod = "Yearly"

--- a/split_landmask.py
+++ b/split_landmask.py
@@ -34,7 +34,7 @@ def main():
     # Check if extent is global or regional
     bbox = [-180.0, 180.0, -90.0, 90.0]
     if args.extent != "global":
-        bbox = [coord for coord in args.extent.split(",")]
+        bbox = [float(coord) for coord in args.extent.split(",")]
 
     # Read in the landmask
     landmask_in = xr.open_dataset(args.landmask_file)["land"]


### PR DESCRIPTION
This makes some changes to the ```cru.nml``` namelist and adds a ```met_names.nml``` namelist. The changes in the ```cru.nml``` file reflect the changes made (on the development branch) to both the input routines for the Met forcing, and the way we handle NetCDF internal variable names, which are not consistent across datasets.

The changes in ```cru.nml``` demonstrate the changes made in specifying input datasets to permit datasets spanning multiple files. There is no need to merge this branch into main any time soon, as the development of the routines in CABLE is likely to go through a couple of iterations before being merged into the CABLE-POP_TRENDY branch. This branch will remain tied to the [212_POP-Prepare-for-CMIP6](https://github.com/CABLE-LSM/CABLE/tree/212_POP-Prepare-for-CMIP6) branch.