### PR TITLE
Update scripts for Trendy runs

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -22,39 +22,53 @@ climate_restart='cru_climate_rst'
 keep_dump=1
 mergesteps='1700_1900 1901_2022'
 
+# Info
+echo ""
+echo "Cleaning ${exp_name}"
+echo "in path ${outpath}"
+echo "Keeping dump: ${keep_dump}"
+echo "for steps: ${mergesteps}"
+echo ""
 
 # executable
+echo "Move executable"
 mkdir -p ${outpath}/exe
-mv ${outpath}/run1/cable ${outpath}/exe/.
+mv ${outpath}/run1/cable ${outpath}/exe/
 
-# PBS log files
-mkdir -p ${outpath}/PBS
-mv ${PWD}/${exp_name}.o* ${outpath}/PBS/.
+# job files
+echo "Move job output files"
+mkdir -p ${outpath}/job
+mv ${PWD}/${exp_name}.o* ${outpath}/job/
 
+echo "Move restart files, logs, landmasks, and dump files"
+echo "Delete run directories"
 for ((irun=1; irun<=${nruns}; irun++)) ; do
-
-    # Restart files (includes namelists)
+    # Restart files (incl. namelists)
     mkdir -p ${outpath}/restart/run${irun}
-    mv ${outpath}/run${irun}/restart/* ${outpath}/restart/run${irun}/.
+    mv ${outpath}/run${irun}/restart/* ${outpath}/restart/run${irun}/
 
-    # Climate restart
+    # Climate restart file
     mkdir -p ${outpath}/climate_restart
     mv ${outpath}/run${irun}/${climate_restart}.nc ${outpath}/climate_restart/${climate_restart}${irun}.nc
 
     # log files
     mkdir -p ${outpath}/logs/run${irun}
-    mv ${outpath}/run${irun}/logs/* ${outpath}/logs/run${irun}/.
+    mv ${outpath}/run${irun}/logs/* ${outpath}/logs/run${irun}/
 
     # landmasks
     mkdir -p ${outpath}/landmasks
-    mv ${outpath}/run${irun}/landmask/landmask${irun}.nc ${outpath}/landmasks/.
+    mv ${outpath}/run${irun}/landmask/landmask${irun}.nc ${outpath}/landmasks/
 
     # dump files
     if [[ ${keep_dump} -eq 1 || ("${outpath}" == "S3*" && ("${mergesteps}" == "*1700_1900" || "${mergesteps}" == "1901_*")) ]] ; then
         mkdir -p ${outpath}/dump_files/run${irun}
-        mv ${outpath}/run${irun}/*_dump.nc ${outpath}/dump_files/run${irun}/.
+        mv ${outpath}/run${irun}/*_dump.nc ${outpath}/dump_files/run${irun}/
     fi
 
     # delete all the rest
     rm -r ${outpath}/run${irun}/
 done
+
+echo "Finished cleaning ${exp_name}"
+
+exit

--- a/merge_to_output2d.py
+++ b/merge_to_output2d.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 """
 usage: merge_to_output2d.py [-h] [-o output_netcdf] [-v] [-z] [files ...]
 
@@ -28,7 +27,10 @@ Example
 History
 -------
 Written  Matthias Cuntz, May 2020
-             - from unpack_to_output2d.py
+    - from unpack_to_output2d.py
+Modified Matthias Cuntz, May 2024
+    - formatted strings in all print statements
+    - better formatting of print of variable slices
 
 Remember:
 https://chase-seibert.github.io/blog/2013/08/03/diagnosing-memory-leaks-python.html
@@ -94,7 +96,7 @@ gb = 1073741824.  # (1024 * 1024 * 1024)
 ifile = ifiles[0]
 fi = nc.Dataset(ifile, 'r')
 if verbose:
-    print('Check first input file:', ifile)
+    print(f'Check first input file: {ifile}')
 ncvars = list(fi.variables.keys())
 ntime = fi.dimensions['time'].size
 
@@ -102,7 +104,7 @@ ntime = fi.dimensions['time'].size
 if ofile is None:  # Default output filename
     ofile = pj.ncio.set_output_filename(ifile, '-merged')
 if verbose:
-    print('Create output file:', ofile)
+    print(f'Create output file: {ofile}')
 if izip:
     oformat = 'NETCDF4'
 else:
@@ -295,8 +297,8 @@ for ncvar in ncvars:
             fi = nc.Dataset(ifile, 'r')
             ivar = fi.variables[ncvar][:]
             if not np.all(ivar00 == ivar):
-                print('ivar0', ivar00)
-                print('ivar', ivar)
+                print(f'ivar0: {ivar00}')
+                print(f'ivar:  {ivar}')
                 fi.close()
                 fo.close()
                 raise ValueError(f'variable {ncvar} not equal in file'
@@ -326,7 +328,8 @@ for ncvar in ncvars:
         del outvar
     else:  # has time and land/ntile
         fi0.close()
-        print(f'        {ovar.shape}')
+        if verbose:
+            print(f'        {ovar.shape}')
         nt = np.ceil(np.prod(ovar.shape) * 8 / gb / 2).astype(int)
         tindexes = np.linspace(0, ntime, nt+1, dtype=int)
         for nn in range(nt):
@@ -334,8 +337,8 @@ for ncvar in ncvars:
             i1 = tindexes[nn]
             i2 = tindexes[nn + 1]
             oshape[0] = i2 - i1
-            if nt > 1:
-                print(f'        {oshape} {i1} {i2}')
+            if verbose:
+                print(f'            {oshape} {i1} {i2}')
             outvar = np.full(oshape,
                              pj.ncio.get_fill_value_for_dtype(ivar0_dtype))
             mem = psutil.Process().memory_info()
@@ -353,25 +356,26 @@ for ncvar in ncvars:
             # write to disk in one go
             if verbose:
                 tstopread = ptime.time()
-                print('        Read  {:.2f} s'.format(tstopread - tstartread))
+                print(f'            Read  {tstopread - tstartread:.2f} s')
                 tstartwrite = tstopread
             ovar[i1:i2, ...] = outvar
             if verbose:
                 tstopwrite = ptime.time()
-                print('        Wrote {:.2f} s'.format(tstopwrite - tstartwrite))
+                print(f'            Wrote {tstopwrite - tstartwrite:.2f} s')
                 mem = psutil.Process().memory_info()
-                print(f'        Memory physical [GB]: {mem.rss / gb:.2f} virtual: {mem.vms / gb:.2f}')
+                print(f'            Memory physical [GB]: {mem.rss / gb:.2f},'
+                      f' virtual: {mem.vms / gb:.2f}')
             del outvar
     fo.close()
     del ivar0, ovar
     gc.collect()
     if verbose:
         tstopvar = ptime.time()
-        print('        Total {:.2f} s'.format(tstopvar - tstartvar))
+        print(f'        Total {tstopvar - tstartvar:.2f} s')
 
 # -------------------------------------------------------------------------
 # Finish
 
 if verbose:
     tstop = ptime.time()
-    print('Finished in [s]: {:.2f}'.format(tstop - tstart))
+    print(f'Finished in [s]: {tstop - tstart:.2f}')

--- a/run_TRENDY.sh
+++ b/run_TRENDY.sh
@@ -45,9 +45,13 @@ keep_dump=1                             # keep dump files (1) or discard (0)? Th
 # Code directory- set this to where your version of the code is located
 cablecode=""
 # Run directory
-rundir=$(pwd)
+rundir="${PWD}"
 # Output directory- where the results are written to
 outpath="${rundir}/${experiment_name}"
+# Parameter directory
+paramdir="${cablecode}/params/v12"
+# LUT directory
+lutdir="${cablecode}/params"
 
 # The various scripts used are contained in the configuration repository
 landmask_script="${rundir}/split_landmask.py"
@@ -73,49 +77,85 @@ GlobalTransitionFilePath="${datadir}/luc/LUH2_GCB_1x1/v2023"
 SurfaceFile="${datadir}/gridinfo/gridinfo_CSIRO_1x1.nc"
 # Global Land Mask
 GlobalLandMaskFile="${datadir}/landmask/glob_ipsl_1x1.nc"
+# vegetation parameters
+filename_veg="${paramdir}/def_veg_params.txt"
+# soil parameters
+filename_soil="${paramdir}/def_soil_params.txt"
+# casa-cnp parameters
+casafile_cnpbiome="${paramdir}/pftlookup.csv"
+# mesophyll conductance lookup tables
+gm_lut_bernacchi_2002="${lutdir}/gm_LUT_351x3601x7_1pt8245_Bernacchi2002.nc"
+gm_lut_walker_2013="${lutdir}/gm_LUT_351x3601x7_1pt8245_Walker2013.nc"
+# 13C
+filename_d13c_atm="${lutdir}/graven_et_al_gmd_2017-table_s1-delta_13c-1700-2025.txt"
 
-## ---------------------------- End Settings ---------------------------------- ## 
+# OS and Workload manager
+ised="sed --in-place=.old"  # Linux: "sed --in-place=.old" ; macOS/Unix: "sed -i .old"
+pqsub="qsub"  # PBS: "qsub" ; Slurm: "sbatch --parsable"
+# PBS: qsub -W "depend=afterok:id1:id2"
+# Slurm: sbatch --dependency=afterok:id1:id2
+function dqsub()
+{
+    # PBS
+    echo "qsub -W \"depend=afterok${1}\""
+    # # Slurm
+    # echo "sbatch --parsable --dependency=afterok${1}"
+}
+ntag="PBS -N "  # PBS: "PBS -N " ; Slurm: "SBATCH --job-name="
 
 # -----------------------------------------------------------------------
 # 1) Create landmasks (created in folders ${outpath}/runX/landmask)
 # -----------------------------------------------------------------------
 if [[ ${create_landmasks} -eq 1 ]] ; then
-   $landmask_script $GlobalLandMaskFile $nruns $outpath -e $extent
+    echo "Create landmasks"
+    ${landmask_script} ${GlobalLandMaskFile} ${nruns} ${outpath} -e ${extent}
+    echo "Finished creating landmasks"
 fi
 
 # -----------------------------------------------------------------------
 # 2) Run CABLE
 # -----------------------------------------------------------------------
+RUN_IDS=
 if [[ ${run_model} -eq 1 ]] ; then
+    echo "Submit model runs"
     # 2.1) Write general settings into run script
-    sed -i "s!^#PBS -N.*!#PBS -N TRENDY_${experiment_name}!" $run_script
-    sed -i "s!^experiment=.*!experiment='${experiment}'!" $run_script
-    sed -i "s!^experiment_name=.*!experiment_name='${experiment_name}'!" $run_script
-    sed -i "s!^cablecode=.*!cablecode='${cablecode}'!" $run_script
-    sed -i "s!^rundir=.*!rundir='${rundir}'!" $run_script
-    sed -i "s!^scriptdir=.*!scriptdir='${scriptdir}'!" $run_script
-    sed -i "s!^datadir=.*!datadir='${datadir}'!" $run_script
-    sed -i "s!^exe=.*!exe='${exe}'!" $run_script
-    sed -i "s!^MetPath=.*!MetPath='${GlobalMetPath}'!" $run_script
-    sed -i "s!^MetVersion=.*!MetVersion='${MetVersion}'!" $run_script
-    sed -i "s!^TransitionFilePath=.*!TransitionFilePath='${GlobalTransitionFilePath}'!" $run_script
-    sed -i "s!^SurfaceFile=.*!SurfaceFile='${SurfaceFile}'!" $run_script
+    ${ised} -e "s|^#${ntag}.*|#${ntag}${experiment_name}|" ${run_script}
+    ${ised} -e "s|^experiment=.*|experiment='${experiment}'|" ${run_script}
+    ${ised} -e "s|^experiment_name=.*|experiment_name='${experiment_name}'|" ${run_script}
+    ${ised} -e "s|^cablecode=.*|cablecode='${cablecode}'|" ${run_script}
+    ${ised} -e "s|^rundir=.*|rundir='${rundir}'|" ${run_script}
+    ${ised} -e "s|^datadir=.*|datadir='${datadir}'|" ${run_script}
+    ${ised} -e "s|^exe=.*|exe='${exe}'|" ${run_script}
+    ${ised} -e "s|^MetPath=.*|MetPath='${GlobalMetPath}'|" ${run_script}
+    ${ised} -e "s|^MetVersion=.*|MetVersion='${MetVersion}'|" ${run_script}
+    ${ised} -e "s|^TransitionFilePath=.*|TransitionFilePath='${GlobalTransitionFilePath}'|" ${run_script}
+    ${ised} -e "s|^SurfaceFile=.*|SurfaceFile='${SurfaceFile}'|" ${run_script}
+    ${ised} -e "s|^filename_veg=.*|filename_veg='${filename_veg}'|" ${run_script}
+    ${ised} -e "s|^filename_soil=.*|filename_soil='${filename_soil}'|" ${run_script}
+    ${ised} -e "s|^casafile_cnpbiome=.*|casafile_cnpbiome='${casafile_cnpbiome}'|" ${run_script}
+    ${ised} -e "s|^gm_lut_bernacchi_2002=.*|gm_lut_bernacchi_2002='${gm_lut_bernacchi_2002}'|" ${run_script}
+    ${ised} -e "s|^gm_lut_walker_2013=.*|gm_lut_walker_2013='${gm_lut_walker_2013}'|" ${run_script}
+    ${ised} -e "s|^filename_d13c_atm=.*|filename_d13c_atm='${gm_lut_bernacchi_2002}'|" ${run_script}
+    ${ised} -e "s|^ised=.*|ised='${ised}'|" ${run_script}
 
     # 2.2) Loop over landmasks and start runs
     for ((irun=1; irun<=${nruns}; irun++)) ; do
         runpath="${outpath}/run${irun}"
-        sed -i "s!^runpath=.*!runpath='${runpath}'!" $run_script
-        sed -i "s!^LandMaskFile=.*!LandMaskFile='${runpath}/landmask/landmask${irun}.nc'!" $run_script
-
-        RUN_IDS="${RUN_IDS}:$(qsub $run_script)"
+        ${ised} -e "s|^runpath=.*|runpath='${runpath}'|" ${run_script}
+        ${ised} -e "s|^LandMaskFile=.*|LandMaskFile='${runpath}/landmask/landmask${irun}.nc'|" ${run_script}
+        RUN_IDS="${RUN_IDS}:$(${pqsub} ${run_script})"
     done
+
+    if [[ -f ${run_script}.old ]] ; then rm ${run_script}.old ; fi
+
+    echo "Submitted model jobs ${RUN_IDS}"
 fi
 
 # -----------------------------------------------------------------------
 # 3) Merge outputs (only if all previous runs were OK)
 # -----------------------------------------------------------------------
 if [[ ${merge_results} -eq 1 ]] ; then
-    
+    echo "Submit merge jobs"
     ftypes="cable casa LUC"
     outfinal="${outpath}/output"
     if [[ -d ${outfinal} ]] ; then
@@ -126,27 +166,37 @@ if [[ ${merge_results} -eq 1 ]] ; then
     for mergestep in ${mergesteps} ; do
         for ftype in ${ftypes} ; do
             if [[ ("${ftype}" != "LUC") || ("${experiment}" == "S3" && ("${mergestep}" == "1700_1900" || "${mergestep}" == "1901_"* )) ]] ; then
-                sed -i "s!^python3.*!python3 ${rundir}/scripts/aux/merge_to_output2d.py -o ${outfinal}/cru_out_${ftype}_${mergestep}.nc ${outpath}/run*/outputs/cru_out_${ftype}_${mergestep}.nc!" $merge_script
+                ${ised} -e "s|^python3.*|python3 ${rundir}/merge_to_output2d.py -v -z -o ${outfinal}/cru_out_${ftype}_${mergestep}.nc ${outpath}/run*/outputs/cru_out_${ftype}_${mergestep}.nc|" ${merge_script}
                 if [[ ${run_model} -eq 1 ]] ; then
-                    MERGE_IDS="${MERGE_IDS}:$(qsub -W "depend=afterok${RUN_IDS}" $merge_script)"
+                    MERGE_IDS="${MERGE_IDS}:$($(dqsub ${RUN_IDS}) ${merge_script})"
                 else
-                    MERGE_IDS="${MERGE_IDS}:$(qsub $merge_script)"
+                    MERGE_IDS="${MERGE_IDS}:$(${pqsub} ${merge_script})"
                 fi
             fi
         done
     done
 
+    if [[ -f ${merge_script}.old ]] ; then rm ${merge_script}.old ; fi
+
+    echo "Submitted merge jobs ${MERGE_IDS}"
+
     # -----------------------------------------------------
     # 4) Backup and cleanup
     # -----------------------------------------------------
 
-    sed -i "s!^exp_name=.*!exp_name='TRENDY_${experiment_name}'!" $cleanup_script
-    sed -i "s!^outpath=.*!outpath='${outpath}'!" $cleanup_script
-    sed -i "s!^nruns=.*!nruns=${nruns}!" $cleanup_script
-    sed -i "s!^climate_restart=.*!climate_restart='${climate_restart}'!" $cleanup_script
-    sed -i "s!^keep_dump=.*!keep_dump=${keep_dump}!" $cleanup_script
-    sed -i "s!^mergesteps=.*!mergesteps='${mergesteps}'!" $cleanup_script
+    echo "Submit cleaning job"
+    ${ised} -e "s|^exp_name=.*|exp_name='${experiment_name}'|" ${cleanup_script}
+    ${ised} -e "s|^outpath=.*|outpath='${outpath}'|" ${cleanup_script}
+    ${ised} -e "s|^nruns=.*|nruns=${nruns}|" ${cleanup_script}
+    ${ised} -e "s|^climate_restart=.*|climate_restart='${climate_restart}'|" ${cleanup_script}
+    ${ised} -e "s|^keep_dump=.*|keep_dump=${keep_dump}|" ${cleanup_script}
+    ${ised} -e "s|^mergesteps=.*|mergesteps='${mergesteps}'|" ${cleanup_script}
 
-    qsub -W "depend=afterok${MERGE_IDS}" $cleanup_script
+    CLEAN_ID=$(eval $(dqsub ${MERGE_IDS}) ${cleanup_script})
 
+    if [[ -f ${cleanup_script}.old ]] ; then rm ${cleanup_script}.old ; fi
+
+    echo "Submitted clean job ${CLEAN_ID}"
 fi
+
+exit

--- a/split_landmask.py
+++ b/split_landmask.py
@@ -1,27 +1,45 @@
-#!/g/data/hh5/public/apps/cms_conda_scripts/analysis3.d/bin/python3
-# Program to split the global landmask into submasks
-# The split ensures we pick land points from various regions
-# to avoid having all land points frozen if picking all
-# of Greenland for example.
+#!/usr/bin/env python3
+"""
+Program to split the global landmask into submasks
 
+The split ensures we pick land points from various regions
+to avoid having all land points frozen if picking all
+of Greenland, for example.
+
+History
+    * Written Mar 2024 by Lachlan Whyborn
+    * PEP 8 compliance, May 2024, Matthias Cuntz
+    * Added file docstring with history, May 2024, Matthias Cuntz
+    * More explanatory help messages, May 2024, Matthias Cuntz
+    * Removed bug if extent given, May 2024, Matthias Cuntz
+    * Output short datatype instead of byte, May 2024, Matthias Cuntz
+
+"""
 import argparse
-
 import numpy as np
 import xarray as xr
 import os
 
 
 def generate_parser():
-    """Generate the argument parser"""
+    """
+    Generate the argument parser
+
+    """
     args = argparse.ArgumentParser(
-        description="Generate land masks for CABLE to split a global run in a series of serial runs."
-    )
-    args.add_argument("landmask_file", help="Initial global landmask")
-    args.add_argument("nmasks", help="Number of runs for CABLE-POP", type=int)
-    args.add_argument("outpath", help="Root path for output files")
-    args.add_argument(
-        "-e", "--extent", help='"global" or "lon_min,lon_max,lat_min,lat_max"', type=str, default = "global"
-    )
+        description=("Generate land masks for CABLE to split a global run"
+                     " in a series of runs."))
+    args.add_argument("global_landmask_file",
+                      help="Initial global landmask file")
+    args.add_argument("nmasks", type=int,
+                      help="Number of output sub-landmasks")
+    args.add_argument("outpath",
+                      help=("Root path for output files. Files will be:"
+                            "{outpath}/run{num}/landmask/landmask{num}.nc"))
+    args.add_argument("-e", "--extent", type=str, default="global",
+                      help=('Extent of latitude and longitude in output file:'
+                            ' "global" (default) or'
+                            ' "lon_min,lon_max,lat_min,lat_max"'))
 
     return args
 
@@ -34,27 +52,27 @@ def main():
     # Check if extent is global or regional
     bbox = [-180.0, 180.0, -90.0, 90.0]
     if args.extent != "global":
-        bbox = [coord for coord in args.extent.split(",")]
+        bbox = [ float(coord) for coord in args.extent.split(",") ]
 
     # Read in the landmask
-    landmask_in = xr.open_dataset(args.landmask_file)["land"]
+    landmask_in = xr.open_dataset(args.global_landmask_file)["land"]
 
     # Cut the data to the extent required. We need to sort
     # the latitude in ascending order first and then revert if needed
     is_ascending = landmask_in["latitude"][0] < landmask_in["latitude"][1]
     landmask_cut = landmask_in.sortby("latitude").sel(
-        latitude=slice(bbox[2], bbox[3]), longitude=slice(bbox[0], bbox[1])
-    )
+        latitude=slice(bbox[2], bbox[3]), longitude=slice(bbox[0], bbox[1]))
     landmask_cut = landmask_cut.sortby("latitude", ascending=is_ascending)
 
     # Create composite mask for all the runs.
     run_mask = create_run_mask(landmask_cut, args.nmasks)
 
-    # Reindex the local run mask to be the same as the global land mask. Set the fill value to 0 i.e. not active.
-    run_mask = run_mask.reindex_like(landmask_in, fill_value = 0)
+    # Reindex the local run mask to be the same as the global land
+    # mask. Set the fill value to 0 i.e. not active.
+    run_mask = run_mask.reindex_like(landmask_in, fill_value=0)
 
     # Save mask to file to allow for an easy check.
-    os.makedirs(f"{args.outpath}", exist_ok = True)
+    os.makedirs(f"{args.outpath}", exist_ok=True)
     run_mask.to_netcdf(f"{args.outpath}/check_landmask.nc")
 
     # Write the mask for each run to a separate file
@@ -62,20 +80,20 @@ def main():
         # Write files for each mask. Each mask has 1 over the land
         # points for that mask and 0 everywhere else.
         # Fill missing with 0. and save as bytes.
-        landmask_per_run = landmask_in.where(run_mask == i + 1, 0)
-        os.makedirs(f"{args.outpath}/run{i+1}/landmask", exist_ok = True)
+        landmask_per_run = landmask_in.where(run_mask==i + 1, 0)
+        os.makedirs(f"{args.outpath}/run{i+1}/landmask", exist_ok=True)
         landmask_per_run.to_netcdf(
             f"{args.outpath}/run{i+1}/landmask/landmask{i+1}.nc",
-            encoding={landmask_per_run.name: {"dtype": np.byte, "_FillValue": 0}},
-        )
+            encoding={landmask_per_run.name:
+                      {"dtype": np.short, "_FillValue": 0}})
 
 
 def create_run_mask(
     landmask_in: xr.DataArray,
-    nmasks: int,
-) -> xr.DataArray:
-    """Create the full mask per run. The mask has a value N for
-    points done by run N.
+    nmasks: int) -> xr.DataArray:
+    """
+    Create the full mask per run. The mask has a value N for points
+    done by run N.
 
     Parameters
     ----------
@@ -90,6 +108,7 @@ def create_run_mask(
     -------
     xr.DataArray
         New mask created with value N for a land point for the run N.
+
     """
     # Number of land points total and
     # number of land points per processor


### PR DESCRIPTION
While porting the scripts for Trendy to our cluster, which uses SLURM, I also updated the scripts in more general terms:

- I am more verbose in `cleanup.sh`. I also use a directory `job/` instead of `PBS/` for the job outputs for easier portability.
- I updated `merge_to_output2d.py` having better formatting of the print statements.
- I updated the `split_landmask.py` by using short instead of byte ouput type to be consistent with the global landmask file. The extent is now converted to float and not left as string. And I updated the help messages in the argument parser.
- There are two more functions in `run_cable-pop_lib.sh`: nckslatlon and saveid. The latter does all the cleaning up after the individual steps in `run_cable.sh`, and the former is used in another script (`latlon_meteo.sh`) in the branch nancy_biocomp.
- `run_cable.sh` now uses saveid, which makes it easier to read and maintain the script.
- `run_TRENDY.sh` passes now also all parameter files to `run_cable.sh`, which was hard-coded before.
